### PR TITLE
Fix base path to match repo name (seventh-seal-chess)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memento-mori",
   "private": true,
-  "homepage": "https://tur7er.github.io/memento-mori",
+  "homepage": "https://tur7er.github.io/seventh-seal-chess",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { Deploy } from './pages/Deploy'
 
 export default function App() {
   return (
-    <BrowserRouter basename="/memento-mori">
+    <BrowserRouter basename="/seventh-seal-chess">
       <Nav />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/ChapterCard.jsx
+++ b/src/components/ChapterCard.jsx
@@ -146,7 +146,7 @@ export function ChapterCard({ chapter }) {
                 <p style={{ color: 'var(--ink-300)', fontStyle: 'italic', marginBottom: '1rem' }}>
                   This chapter is available with a Seeker subscription.
                 </p>
-                <a href="/memento-mori/pricing" className="btn btn-blood" style={{ textDecoration: 'none' }}>
+                <a href="/seventh-seal-chess/pricing" className="btn btn-blood" style={{ textDecoration: 'none' }}>
                   Upgrade to Seeker
                 </a>
               </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/memento-mori/',
+  base: '/seventh-seal-chess/',
 })


### PR DESCRIPTION
The app was deployed under the seventh-seal-chess repo but had base path set to /memento-mori/. Updated vite config, router basename, and package.json homepage to use /seventh-seal-chess/.

https://claude.ai/code/session_01NeQA2T8CMB8GYCBsj6vfmw